### PR TITLE
Fix dead lock in Azure

### DIFF
--- a/test-solution-template.groovy
+++ b/test-solution-template.groovy
@@ -90,7 +90,6 @@ def RunSolutionTemplateTests(options) {
 
             try {
                 runJenkinsTests(sshCommand: ssh_command, utilsLocation: options.utilsLocation)
-            } catch(e) {
             } finally {
                 sh ssh_command + ' -S ' + socket + ' -O exit'
             }


### PR DESCRIPTION
This empty `catch` will cause none of the `az lock delete` command being executed when there is exception thrown from the runJenkinsTests method. This will finally leave a dead lock on the test resources.

[az lock delete 1](https://github.com/Microsoft/vscjenkins-ci-scripts/blob/b68ddb9eeb33a47d7260d5d11d337d4a4b8480d7/test-solution-template.groovy#L100)
[az lock delete 2](https://github.com/Microsoft/vscjenkins-ci-scripts/blob/b68ddb9eeb33a47d7260d5d11d337d4a4b8480d7/test-solution-template.groovy#L104)
